### PR TITLE
Use native fetch instead of fetch-node

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,6 @@
 name: CI
 
 on:
-    workflow_dispatch: {}
     push:
         branches:
             - main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,15 +39,15 @@ jobs:
             - name: Setup node
               uses: actions/setup-node@v4
               with:
-                  node-version: 18
+                  node-version: 22
                   registry-url: https://npm.pkg.github.com/
 
             - uses: actions/cache@v4
               id: yarn-cache
               with:
                   path: '**/node_modules'
-                  key: ${{ runner.os }}-node18-yarn-${{ hashFiles('**/yarn.lock') }}
-                  restore-keys: ${{ runner.os }}-node18-yarn-
+                  key: ${{ runner.os }}-node22-yarn-${{ hashFiles('**/yarn.lock') }}
+                  restore-keys: ${{ runner.os }}-node22-yarn-
 
             - name: Build Typescript
               run: yarn && yarn build
@@ -63,7 +63,7 @@ jobs:
             - name: Setup node
               uses: actions/setup-node@v4
               with:
-                  node-version: 18
+                  node-version: 22
                   registry-url: https://npm.pkg.github.com/
 
             - name: Get yarn cache directory path

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ use. A [free trial of Cloudcraft Pro](https://www.cloudcraft.co/pricing) with AP
 
 ## Requirements
 
-Node 18 or higher.
+Node 22 or higher.
 
 ## Installation
 

--- a/lib/restclient.ts
+++ b/lib/restclient.ts
@@ -2,8 +2,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2024-Present Datadog, Inc.
 
-import fetch, { FetchError } from 'node-fetch';
-
 import { ClientConfig } from './clientconfig';
 import CloudcraftError from './error';
 
@@ -36,9 +34,10 @@ class CloudcraftRestClient {
                 headers: { Authorization: `Bearer ${this.apiKey}` },
             });
         } catch (error) {
-            if (error instanceof FetchError) {
+            if (error instanceof TypeError) {
                 throw new CloudcraftError(error.message);
             }
+
             throw error;
         }
 
@@ -93,9 +92,10 @@ class CloudcraftRestClient {
                 body: JSON.stringify(body),
             });
         } catch (error) {
-            if (error instanceof FetchError) {
+            if (error instanceof TypeError) {
                 throw new CloudcraftError(error.message);
             }
+
             throw error;
         }
 
@@ -124,9 +124,10 @@ class CloudcraftRestClient {
                 body: JSON.stringify(body),
             });
         } catch (error) {
-            if (error instanceof FetchError) {
+            if (error instanceof TypeError) {
                 throw new CloudcraftError(error.message);
             }
+
             throw error;
         }
 
@@ -161,9 +162,10 @@ class CloudcraftRestClient {
                 method: 'DELETE',
             });
         } catch (error) {
-            if (error instanceof FetchError) {
+            if (error instanceof TypeError) {
                 throw new CloudcraftError(error.message);
             }
+
             throw error;
         }
 

--- a/package.json
+++ b/package.json
@@ -43,9 +43,6 @@
         "ts-jest": "^29.1.4",
         "typescript": "5.4.5"
     },
-    "dependencies": {
-        "node-fetch": "2.6.7"
-    },
     "engines": {
         "node": ">=22.*"
     },

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
         "node-fetch": "2.6.7"
     },
     "engines": {
-        "node": ">=18.*"
+        "node": ">=22.*"
     },
     "nyc": {
         "extension": [

--- a/test/integration/aws.test.ts
+++ b/test/integration/aws.test.ts
@@ -22,7 +22,6 @@ test('test /aws endpoint', async () => {
 
     let accounts = await client.awsAccount.list();
 
-    expect(accounts).toBeInstanceOf(Array);
     expect(accounts.length).toBeGreaterThan(0);
 
     // eslint-disable-next-line no-restricted-syntax
@@ -38,7 +37,6 @@ test('test /aws endpoint', async () => {
 
     accounts = await client.awsAccount.list();
 
-    expect(accounts).toBeInstanceOf(Array);
     expect(accounts.length).toBeGreaterThan(0);
     expect(accounts.find((a) => a.id === account.id)?.name).toEqual(account.name);
 
@@ -61,7 +59,6 @@ test('test /aws endpoint', async () => {
 
     const iamParameters = await client.awsAccount.iamParameters();
 
-    expect(iamParameters).toBeInstanceOf(Object);
     expect(iamParameters.accountId).toBeDefined();
     expect(iamParameters.externalId).toBeDefined();
     expect(iamParameters.awsConsoleUrl).toBeDefined();

--- a/test/integration/blueprint.test.ts
+++ b/test/integration/blueprint.test.ts
@@ -16,13 +16,11 @@ test('test /blueprint endpoint', async () => {
     const blueprint = await client.blueprint.create(giveBlueprint);
 
     expect(blueprint.id).toHaveLength(36);
-    expect(blueprint.data).toBeInstanceOf(Object);
     expect(blueprint.data.grid).toEqual(giveBlueprint.data.grid);
     expect(blueprint.data.name).toEqual(giveBlueprint.data.name);
 
     const blueprints = await client.blueprint.list();
 
-    expect(blueprints).toBeInstanceOf(Array);
     expect(blueprints.length).toBeGreaterThan(0);
 
     // eslint-disable-next-line no-restricted-syntax

--- a/test/integration/user.test.ts
+++ b/test/integration/user.test.ts
@@ -6,7 +6,6 @@ test('test /user endpoint', async () => {
 
     expect(user.id).toHaveLength(36);
     expect(user.name).toBeDefined();
-    expect(user.settings).toBeInstanceOf(Object);
     expect(user.createdAt).toBeInstanceOf(Date);
     expect(user.updatedAt).toBeInstanceOf(Date);
     expect(user.accessedAt).toBeInstanceOf(Date);

--- a/test/mock/aws.test.ts
+++ b/test/mock/aws.test.ts
@@ -177,8 +177,6 @@ test('successfully list AWS accounts', async () => {
     const client = new Cloudcraft(testApiKey);
     const accounts = await client.awsAccount.list();
 
-    expect(accounts).toBeInstanceOf(Array);
-
     // eslint-disable-next-line no-restricted-syntax
     for (const account of accounts) {
         expect(account.id).toHaveLength(36);
@@ -190,7 +188,6 @@ test('successfully get IAM parameters', async () => {
     const client = new Cloudcraft(testApiKey);
     const iamParameters = await client.awsAccount.iamParameters();
 
-    expect(iamParameters).toBeInstanceOf(Object);
     expect(iamParameters.accountId).toBeDefined();
     expect(iamParameters.externalId).toBeDefined();
     expect(iamParameters.awsConsoleUrl).toBeDefined();

--- a/test/mock/blueprint.test.ts
+++ b/test/mock/blueprint.test.ts
@@ -249,8 +249,6 @@ test('successfully list blueprints', async () => {
     const client = new Cloudcraft(testApiKey);
     const blueprints = await client.blueprint.list();
 
-    expect(blueprints).toBeInstanceOf(Array);
-
     // eslint-disable-next-line no-restricted-syntax
     for (const blueprint of blueprints) {
         expect(blueprint.id).toHaveLength(36);
@@ -263,7 +261,6 @@ test('successfully get blueprint', async () => {
     const blueprint = await client.blueprint.get(testBlueprintId);
 
     expect(blueprint.id).toEqual(testBlueprintId);
-    expect(blueprint.data).toBeInstanceOf(Object);
     expect(blueprint.data.name).toEqual(testBlueprintName);
 });
 

--- a/test/mock/user.test.ts
+++ b/test/mock/user.test.ts
@@ -37,7 +37,6 @@ test('get user information', async () => {
 
     expect(user.id).toHaveLength(36);
     expect(user.name).toBeDefined();
-    expect(user.settings).toBeInstanceOf(Object);
     expect(user.createdAt).toBeInstanceOf(Date);
     expect(user.updatedAt).toBeInstanceOf(Date);
     expect(user.accessedAt).toBeInstanceOf(Date);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3581,13 +3581,6 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
-node-fetch@2.6.7:
-  version "2.6.7"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
-  integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
-  dependencies:
-    whatwg-url "^5.0.0"
-
 node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
@@ -4343,11 +4336,6 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
-tr46@~0.0.3:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
-  integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
-
 ts-api-utils@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/ts-api-utils/-/ts-api-utils-1.3.0.tgz#4b490e27129f1e8e686b45cc4ab63714dc60eea1"
@@ -4521,19 +4509,6 @@ walker@^1.0.8:
   integrity sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==
   dependencies:
     makeerror "1.0.12"
-
-webidl-conversions@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
-  integrity sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==
-
-whatwg-url@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
-  integrity sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==
-  dependencies:
-    tr46 "~0.0.3"
-    webidl-conversions "^3.0.0"
 
 which-boxed-primitive@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
### What does this PR do?
Updates the code to use `fetch` natively instead of relying on `fetch-node`. This means we're dependency free, but also means we now require Node 22 and above.

### Review checklist

Please check relevant items below:

-   [x] The title & description contain a short meaningful summary of work completed.
-   [x] Tests have been updated/created and are passing locally.
-   [x] I've reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file.
