### PR TITLE
Add "dist" directory to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
     },
     "author": "Datadog, Inc. <dev@datadoghq.com> (https://www.datadoghq.com/)",
     "license": "Apache-2.0",
+    "files": [
+        "dist/**/*"
+    ],
     "devDependencies": {
         "@types/eslint": "^8.56.10",
         "@types/jest": "^29.5.12",


### PR DESCRIPTION
### What does this PR do?
Add a `files` section to `package.json` to include the `dist` directory in the archive when running `yarn pack`. This is probably needed for `yarn publish` as well.

### Review checklist

Please check relevant items below:

-   [x] The title & description contain a short meaningful summary of work completed.
-   [x] Tests have been updated/created and are passing locally.
-   [x] I've reviewed the [CONTRIBUTING.md](../CONTRIBUTING.md) file.
